### PR TITLE
feat: реализация бизнес-логики получения профиля пользователя

### DIFF
--- a/src/main/java/com/dmitry/dto/UsersDTO.java
+++ b/src/main/java/com/dmitry/dto/UsersDTO.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -20,6 +21,7 @@ import java.util.List;
 @AllArgsConstructor
 public class UsersDTO {
 
+    @Schema(description = "ID пользователя")
     private Long id;
 
     @Schema(description = "Имя пользователя. Обязательно. Максимум 500 символов.")
@@ -40,4 +42,8 @@ public class UsersDTO {
     @Schema(description = "Список телефонов пользователя. Должен содержать хотя бы один элемент.")
     @NotNull(message = "Телефоны обязательны")
     private List<PhoneDTO> phones;
+
+    @Schema(description = "Баланс аккаунта пользователя, отображается в рублях.")
+    @NotNull(message = "Баланс аккаунта обязателен")
+    private BigDecimal balance;
 }

--- a/src/main/java/com/dmitry/mapper/UserMapper.java
+++ b/src/main/java/com/dmitry/mapper/UserMapper.java
@@ -1,0 +1,38 @@
+package com.dmitry.mapper;
+
+import com.dmitry.dto.EmailDTO;
+import com.dmitry.dto.PhoneDTO;
+import com.dmitry.dto.UsersDTO;
+import com.dmitry.entity.Users;
+import org.springframework.stereotype.Component;
+
+/**
+ * Компонент для преобразования сущности {@link Users} в DTO {@link UsersDTO}.
+ * <p>
+ * Используется в сервисе для возврата профиля пользователя.
+ */
+@Component
+public class UserMapper {
+
+    public UsersDTO toDto(Users user) {
+        if (user == null) return null;
+
+        UsersDTO dto = new UsersDTO();
+        dto.setId(user.getId());
+        dto.setName(user.getName());
+        dto.setDateOfBirth(user.getDateOfBirth());
+        dto.setEmails(
+                user.getEmails().stream()
+                        .map(email -> new EmailDTO(email.getEmail()))
+                        .toList()
+        );
+        dto.setPhones(
+                user.getPhones().stream()
+                        .map(phone -> new PhoneDTO(phone.getPhone()))
+                        .toList()
+        );
+        dto.setBalance(user.getAccount().getBalance());
+
+        return dto;
+    }
+}

--- a/src/main/java/com/dmitry/service/UserService.java
+++ b/src/main/java/com/dmitry/service/UserService.java
@@ -1,0 +1,19 @@
+package com.dmitry.service;
+
+import com.dmitry.dto.UsersDTO;
+
+/**
+ * Сервис для работы с пользователями.
+ * <p>
+ * Отвечает за получение профиля текущего пользователя.
+ */
+public interface UserService {
+
+    /**
+     * Возвращает полную информацию о текущем пользователе по его идентификатору.
+     *
+     * @param userId идентификатор пользователя
+     * @return DTO с данными пользователя
+     */
+    UsersDTO getProfile(Long userId);
+}

--- a/src/main/java/com/dmitry/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/dmitry/service/impl/UserServiceImpl.java
@@ -1,0 +1,33 @@
+package com.dmitry.service.impl;
+
+import com.dmitry.dto.UsersDTO;
+import com.dmitry.entity.Users;
+import com.dmitry.mapper.UserMapper;
+import com.dmitry.repository.UserRepository;
+import com.dmitry.service.UserService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Реализация сервиса {@link UserService}.
+ * <p>
+ * Использует репозиторий пользователей и маппер для преобразования сущности в DTO.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UsersDTO getProfile(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Пользователь не найден"));
+
+        return userMapper.toDto(user);
+    }
+}


### PR DESCRIPTION
- добавлен метод UserService#getProfile(Long userId)
- реализован UserMapper для преобразования Users в UsersDTO
- используется @EntityGraph для избежания N+1 при получении связанных emails, phones и account
- возвращаемый профиль содержит: id, name, dateOfBirth, список email/phone, текущий баланс
- Javadoc